### PR TITLE
fix!: Removed preserved paths and reimplemented changelog/version preservation using modifiers

### DIFF
--- a/owlbot-postprocessor/README.md
+++ b/owlbot-postprocessor/README.md
@@ -59,16 +59,17 @@ copying files from the staging directory, and making any desired changes.
 
 For this purpose, the `.owlbot.rb` file will have access to the `OwlBot` module
 which provides useful methods for implementing postprocessing functionality.
-In general, usage of this module involves first configuring various filters and
-content manipulation routines, and then finally calling `OwlBot.move_files`
-which performs the file copying subject to that configuration.
+In general, usage of this module involves first configuring a pipeline of
+_modifiers_ which affect how generated files are handled as they are moved from
+the staging directory, and then finally calling `OwlBot.move_files` which
+performs the file copying subject to that configuration.
 
 Following is an example `.owlbot.rb` file:
 
 ```ruby
 # .owlbot.rb
 
-# Install a content modifier that renames a particular class in all Ruby files
+# Install a modifier that renames a particular class in all Ruby files
 OwlBot.modifier path: %r{^lib/.*\.rb$} do |content|
   content.gsub "BadlyNamedClass", "BetterName"
 end
@@ -93,15 +94,15 @@ OwlBot.move_files
 ```
 
 As a result, if you want to override/disable the default behavior, you will
-need to remove the existing configurations. For example:
+need to remove the existing modifiers from the pipeline. For example:
 
 ```ruby
 # .owlbot.rb
 
 # The changelog is named differently in this library, so remove the default
-# from the preserved paths and add the new one.
-OwlBot.preserved_paths.delete "CHANGELOG.md"
-OwlBot.preserve path: "HISTORY.md"
+# modifier and install a different one.
+OwlBot.remove_modifiers_named "prevent_overwrite_of_existing_changelog_file"
+OwlBot.prevent_overwrite_of_existing "HISTORY.md"
 
 OwlBot.move_files
 ```

--- a/owlbot-postprocessor/test/test_owlbot.rb
+++ b/owlbot-postprocessor/test/test_owlbot.rb
@@ -111,7 +111,7 @@ describe OwlBot do
 
     assert_gem_file "hello.txt", "hello world\n"
     assert_gem_file "lib/hello.rb", "puts 'hello'\n"
-    refute ::File.exist? staging_root_dir
+    refute ::File.exist? staging_dir
 
     paths = ::Dir.glob "**/*", base: gem_dir
     assert_equal 3, paths.size # Two files and one directory
@@ -176,8 +176,8 @@ describe OwlBot do
     assert_gem_file "lib/my/gem/version.rb", "VERSION = 'old'\n"
     assert_gem_file "lib/hello.rb", "puts 'hello2'\n"
 
-    assert_equal ["lib/hello.rb"], manifest["generated"]
-    assert_equal ["CHANGELOG.md", "lib/my/gem/version.rb"], manifest["static"]
+    assert_equal ["CHANGELOG.md", "lib/hello.rb", "lib/my/gem/version.rb"], manifest["generated"]
+    assert_equal [], manifest["static"]
   end
 
   it "handles deletion cases" do
@@ -238,7 +238,7 @@ describe OwlBot do
     create_gem_file "lib/bar.rb", "puts 'bar'\n"
     create_gem_file "lib/baz.rb", "puts 'baz'\n"
     create_gem_file ".owlbot.rb", <<~RUBY
-      OwlBot.preserve path: "lib/foo.rb"
+      OwlBot.prevent_overwrite_of_existing "lib/foo.rb"
       OwlBot.modifier path: "lib/bar.rb" do |src|
         src.sub("again", "AGAIN")
       end
@@ -254,8 +254,8 @@ describe OwlBot do
     assert_gem_file "lib/bar.rb", "puts 'bar AGAIN'\n"
     assert_gem_file "lib/baz.rb", "puts 'baz again'\n"
 
-    assert_equal ["lib/bar.rb", "lib/baz.rb"], manifest["generated"]
-    assert_equal [".owlbot.rb", "lib/foo.rb"], manifest["static"]
+    assert_equal ["lib/bar.rb", "lib/baz.rb", "lib/foo.rb"], manifest["generated"]
+    assert_equal [".owlbot.rb"], manifest["static"]
   end
 
   it "omits gitignored files from the static manifest" do


### PR DESCRIPTION
This fixes the odd behavior where changelog and version files initially show up as generated but later "move" to static.