### PR TITLE
fix(rad): Several additional Cloud-RAD fixes

### DIFF
--- a/toys/release/.data/rad-yard-templates/default/layout/yaml/method.rb
+++ b/toys/release/.data/rad-yard-templates/default/layout/yaml/method.rb
@@ -227,7 +227,7 @@ def raise_text
 end
 
 def tag_content tag
-  types = tag.types.map { |type| link_objects type }
+  types = tag.types.to_a.map { |type| link_objects type }
   entry = "- description: \""
   entry += "#{bold tag.name} " if tag.name && !tag.name.empty?
   entry += "(#{types.join ", "})" unless types.empty?

--- a/toys/release/.data/rad-yard-templates/default/layout/yaml/setup.rb
+++ b/toys/release/.data/rad-yard-templates/default/layout/yaml/setup.rb
@@ -8,7 +8,7 @@ def init
   @object = options.item
   @method_list = object_methods @object
   @constants = @object.children.select { |child| child.type == :constant }.sort_by { |child| child.path }
-  @references = @object.children.reject { |child| [:method, :constant].include? child.type }
+  @references = @object.children.reject { |child| [:method, :constant, :classvariable].include? child.type }
 
   # the children yaml field is supposed to list all children of the @object that will somewhere appear in documentation.
   # the references yaml field is for anything under children that wasn't defined within the same yaml page (other classes/modules)
@@ -53,7 +53,7 @@ def full_object_list
   @full_object_list = []
   object_list.each do |obj|
     @full_object_list += object_methods(obj)
-    references = obj.children.reject { |child| [:method, :constant].include? child.type }
+    references = obj.children.reject { |child| [:method, :constant, :classvariable].include? child.type }
     @full_object_list += references
   end
   @full_object_list
@@ -63,7 +63,7 @@ def children_list
   return @children_list if @children_list
 
   @children_list = object_methods(@object)
-  @children_list += @object.children.reject { |child| :method == child.type }
+  @children_list += @object.children.reject { |child| [:method, :classvariable].include? child.type }
   @children_list.reject! do |child| 
     child.visibility == :private || child.tags.any? { |tag| tag.tag_name == "private" }
   end


### PR DESCRIPTION
Two more fixes:

* Fixed a crash when a tag (such as `@yield`) omitted an expected type. This was blocking google-cloud-logging.
* Removed class variables spuriously included in YAML. This was blocking google-cloud-trace.
