### PR TITLE
fix(rad): Escape ampersands and angle brackets in code blocks

### DIFF
--- a/toys/release/.data/rad-yard-templates/default/layout/yaml/format.rb
+++ b/toys/release/.data/rad-yard-templates/default/layout/yaml/format.rb
@@ -161,6 +161,7 @@ def code_tail
 end
 
 def codeblock str
+  str = str.gsub("&", "&amp;").gsub("<", "&lt;").gsub(">", "&gt;")
   code_head + str + code_tail
 end
 


### PR DESCRIPTION
Fixes some formatting bugs when rendering snippetgen samples with client-side streaming. (Those include sample code that uses the `<<` operator.)