### PR TITLE
fix(rad): Omit license, code of conduct, and contributing docs from output

### DIFF
--- a/toys/release/.data/rad-yard-templates/default/fulldoc/yaml/setup.rb
+++ b/toys/release/.data/rad-yard-templates/default/fulldoc/yaml/setup.rb
@@ -43,6 +43,7 @@ def copy_markdown_file source_filename, dest_filename
   content = File.read source_filename
   content = normalize_markdown_newlines content
   content = ensure_markdown_header content, source_filename
+  content = munge_changelog_file_header content if source_filename == "CHANGELOG.md"
   content = munge_markdown_copyright_text content
   content = process_markdown_code_blocks content
   content = transform_local_markdown_links content
@@ -55,7 +56,7 @@ def copy_markdown_file source_filename, dest_filename
 end
 
 def normalize_markdown_newlines content
-  content.sub!(/^\n+/, "")
+  content.sub!(/\A\n+/, "")
   content = "#{content}\n" unless content.end_with? "\n"
   content
 end
@@ -70,6 +71,10 @@ def ensure_markdown_header content, filename
     title = File.basename filename, ".*"
     "# #{title}\n\n#{content}"
   end
+end
+
+def munge_changelog_file_header content
+  content.sub(/\A# [^\n]+\n/, "# Release history for #{ENV["CLOUDRAD_GEM_NAME"]}\n")
 end
 
 def munge_markdown_copyright_text content

--- a/toys/release/build-rad.rb
+++ b/toys/release/build-rad.rb
@@ -33,7 +33,7 @@ def run
     gem "redcarpet", "~> 3.5", ">= 3.5.1"
   end
   yardopts_content = File.read yardopts
-  cmd = ["yard", "doc"] + build_options(yardopts_content)
+  cmd = ["yard", "doc", "--no-yardopts"] + build_options(yardopts_content)
   cmd = ["bundle", "exec"] + cmd if bundle
   env = { "CLOUDRAD_GEM_NAME" => gem_name }
   exec cmd, env: env
@@ -56,7 +56,7 @@ def build_options yardopts_content
     when "--format"
       in_format = true
       next
-    when /^--format[= ]/, ""
+    when /^--format[= ]/, "", "CONTRIBUTING.md", "CODE_OF_CONDUCT.md", /^LICENSE(\.md)?/
       next
     when /^(--[a-z-]+)\s+(.+)$/
       final_options << "#{Regexp.last_match[1]}=#{Regexp.last_match[2]}"


### PR DESCRIPTION
A few cloud-rad fixes:

* Prevent removal of the blank line between the first header and the rest of the content in a markdown file.
* Changelog headers now list the gem name
* Disable the yardopts file when invoking yard, to avoid confusing yard due to duplicated arguments
* Omit the license, code of conduct, and contributing markdown files from the output
