### PR TITLE
feat(owlbot): Preserve release_level repo metadata field

### DIFF
--- a/owlbot-postprocessor/lib/owlbot.rb
+++ b/owlbot-postprocessor/lib/owlbot.rb
@@ -299,6 +299,26 @@ module OwlBot
     end
 
     ##
+    # A convenience method that installs a modifier preserving `release_level`
+    # fields in existing `.repo-metadata.json` files.
+    #
+    # @param name [String] Optional name for the modifier to add. Defaults to
+    #     `"preserve_repo_metadata_release_levels"`.
+    #
+    def preserve_repo_metadata_release_levels name: nil
+      path = [/\.repo-metadata\.json$/]
+      name ||= "preserve_repo_metadata_release_levels"
+      modifier path: path, name: name do |src, dest|
+        if src && dest
+          copyright_regex = /"release_level": "(\w+)"/
+          match = copyright_regex.match dest
+          src = src.sub copyright_regex, "\"release_level\": \"#{match[1]}\"" if match
+        end
+        src
+      end
+    end
+
+    ##
     # A convenience method that installs a modifier preventing overwriting of
     # certain files, if they exist, by newly generated files. This is commonly
     # used to prevent `CHANGELOG.md` and `version.rb` files from being
@@ -321,6 +341,9 @@ module OwlBot
     #
     # * A modifier named `"preserve_existing_copyright_years"` which ensures
     #   the copyright year of existing files is not modified.
+    # * A modifier named `"preserve_repo_metadata_release_levels"` which
+    #   ensures the `"release_level"` field of `.repo-metadata.json` files is
+    #   not modified.
     # * A modifier named `"prevent_overwrite_of_existing_changelog_file"` which
     #   ensures that an existing changelog file is not replaced by the empty
     #   generated changelog.
@@ -335,6 +358,7 @@ module OwlBot
     #
     def install_default_modifiers
       preserve_existing_copyright_years
+      preserve_repo_metadata_release_levels
       prevent_overwrite_of_existing "CHANGELOG.md",
                                     name: "prevent_overwrite_of_existing_changelog_file"
       prevent_overwrite_of_existing "lib/#{@impl.gem_name.tr '-', '/'}/version.rb",

--- a/owlbot-postprocessor/test/test_owlbot.rb
+++ b/owlbot-postprocessor/test/test_owlbot.rb
@@ -230,6 +230,39 @@ describe OwlBot do
     assert_equal [], manifest["static"]
   end
 
+  it "preserves release_level field" do
+    orig_content = <<~CONTENT
+      {
+          "api_id": "foo.googleapis.com",
+          "release_level": "stable",
+          "ruby-rulez": "yeah!"
+      }
+    CONTENT
+    incoming_content = <<~CONTENT
+      {
+          "api_id": "bar.googleapis.com",
+          "release_level": "unknown",
+          "ruby-rulez": "yeah!"
+      }
+    CONTENT
+    resulting_content = <<~CONTENT
+      {
+          "api_id": "bar.googleapis.com",
+          "release_level": "stable",
+          "ruby-rulez": "yeah!"
+      }
+    CONTENT
+    create_gem_file "hello/.repo-metadata.json", orig_content
+    create_gem_file "hello/something-else.json", orig_content
+    create_staging_file "hello/.repo-metadata.json", incoming_content
+    create_staging_file "hello/something-else.json", incoming_content
+
+    invoke_owlbot
+
+    assert_gem_file "hello/.repo-metadata.json", resulting_content
+    assert_gem_file "hello/something-else.json", incoming_content
+  end
+
   it "deals with types changing" do
     create_gem_file "hello", "hello world\n"
     create_gem_file "foo/bar.rb", "puts 'bar'\n"


### PR DESCRIPTION
Update the owlbot postprocessor to preserve the `release_level` repo-metadata field. This field will be updated by other processes in the google-cloud-ruby repo, and we don't want owlbot reverting it.