### PR TITLE
feat(release): Generate yaml with friendlyApiName key for reference docs

### DIFF
--- a/toys/release/.data/rad-yard-templates/default/examples/class_example.yml
+++ b/toys/release/.data/rad-yard-templates/default/examples/class_example.yml
@@ -30,6 +30,10 @@ items:
 
   # The name of the gem. The cloudrad rake task will set this as ENV["CLOUDRAD_GEM_NAME"] before running yard
   module: google-cloud-vision-v1
+  
+  # The friendly API name and version for the gem. This will be set as ENV["CLOUDRAD_FRIENDLY_API_NAME"] before 
+  # running yard.
+  friendlyApiName: "Cloud Vision V1 API"
 
   # The name of the object. Other languages use this field, but changing/removing it
   # doesn't seem to have any affect on our output.
@@ -62,6 +66,7 @@ items:
   langs:
     - ruby
   module: google-cloud-vision-v1
+  friendlyApiName: "Cloud Vision V1 API"
   summary: "Configure the ImageAnnotator Client instance..." # Same as summary above
   type: method
   example: []
@@ -101,6 +106,7 @@ items:
   langs:
     - ruby
   module: google-cloud-vision-v1
+  friendlyApiName: "Cloud Vision V1 API"
   id: "#batch_annotate_images"
   summary: "Run image detection and annotation for a batch of images."
   type: method

--- a/toys/release/.data/rad-yard-templates/default/layout/yaml/_constant.erb
+++ b/toys/release/.data/rad-yard-templates/default/layout/yaml/_constant.erb
@@ -5,6 +5,7 @@
   langs:
     - ruby
   module: <%= ENV["CLOUDRAD_GEM_NAME"] %>
+  friendlyApiName: <%= ENV["CLOUDRAD_FRIENDLY_API_NAME"].to_s.inspect %>
   id: <%= @constant.name %>
   summary: "<%= constant_summary %>"
   type: const

--- a/toys/release/.data/rad-yard-templates/default/layout/yaml/_method.erb
+++ b/toys/release/.data/rad-yard-templates/default/layout/yaml/_method.erb
@@ -4,6 +4,7 @@
   langs:
     - ruby
   module: <%= ENV["CLOUDRAD_GEM_NAME"] %>
+  friendlyApiName: <%= ENV["CLOUDRAD_FRIENDLY_API_NAME"].to_s.inspect %>
   id: "<%= @method.path[@method.path.size - (@method.name.size + 1)..-1] %>"
   summary: "<%= pre_format @method.docstring, min_header: 4 %>"
   type: <%= @method.type %>

--- a/toys/release/.data/rad-yard-templates/default/layout/yaml/_object.erb
+++ b/toys/release/.data/rad-yard-templates/default/layout/yaml/_object.erb
@@ -4,6 +4,7 @@
   langs:
   - ruby
   module: <%= ENV["CLOUDRAD_GEM_NAME"] %>
+  friendlyApiName: <%= ENV["CLOUDRAD_FRIENDLY_API_NAME"].to_s.inspect %>
   id: <%= @object.name %>
   summary: "<%= pre_format @object.docstring, min_header: 2, toplevel_header: true %>"
   type: "<%= @object.type %>"

--- a/toys/release/.data/rad-yard-templates/default/layout/yaml/_reference.erb
+++ b/toys/release/.data/rad-yard-templates/default/layout/yaml/_reference.erb
@@ -2,6 +2,7 @@
   fullName: <%= @reference.path %>
   name: <%= @reference.name %>
   module: <%= ENV["CLOUDRAD_GEM_NAME"] %>
+  friendlyApiName: <%= ENV["CLOUDRAD_FRIENDLY_API_NAME"].to_s.inspect %>
   id: <%= @reference.name %>
   summary: "<%= pre_format @reference.docstring %>"
   parent: <%= @reference.parent %>

--- a/toys/release/build-rad.rb
+++ b/toys/release/build-rad.rb
@@ -19,6 +19,7 @@ desc "Build cloud-rad yardoc"
 flag :bundle
 flag :yardopts, "--yardopts=PATH", default: ".yardopts"
 flag :gem_name, "--gem-name=NAME"
+flag :friendly_api_name, "--friendly-api-name=NAME"
 
 include :exec, e: true
 include :gems, on_missing: :install
@@ -35,7 +36,7 @@ def run
   yardopts_content = File.read yardopts
   cmd = ["yard", "doc", "--no-yardopts"] + build_options(yardopts_content)
   cmd = ["bundle", "exec"] + cmd if bundle
-  env = { "CLOUDRAD_GEM_NAME" => gem_name }
+  env = { "CLOUDRAD_GEM_NAME" => gem_name, "CLOUDRAD_FRIENDLY_API_NAME" => friendly_api_name }
   exec cmd, env: env
   sanity_check
 end


### PR DESCRIPTION
This adds a new argument to the build-rad tool to accept the friendly API name of a gem. This is then added into the yard template for reference pages.