### PR TITLE
feat(owlbot): Analyze the library and set library_type in repo-metadata

### DIFF
--- a/.toys/ci.rb
+++ b/.toys/ci.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+toys_version! "~> 0.14"
+
 desc "Run CI checks"
 
 CHECKS = [:test, :rubocop]
@@ -50,13 +52,7 @@ tool "build" do
   def run
     ::Dir.chdir context_directory
     ::Dir.chdir "owlbot-postprocessor" do
-      cmd = ["toys", "build"]
-      if verbosity > 0
-        cmd << "-#{'v' * verbosity}"
-      elsif verbosity < 0
-        cmd << "-#{'q' * (-verbosity)}"
-      end
-      exec cmd
+      exec ["toys", "build"] + verbosity_flags
     end
   end
 end

--- a/owlbot-postprocessor/test/test_owlbot.rb
+++ b/owlbot-postprocessor/test/test_owlbot.rb
@@ -317,7 +317,7 @@ describe OwlBot do
       assert_gem_file "hello/.repo-metadata.json", resulting_content
     end
 
-    it "sets the library_type to auto if there are handwritten files" do
+    it "sets the library_type to combo if there are handwritten files" do
       incoming_content = <<~CONTENT
         {
             "library_type": "unknown",

--- a/owlbot-postprocessor/test/test_owlbot.rb
+++ b/owlbot-postprocessor/test/test_owlbot.rb
@@ -272,6 +272,74 @@ describe OwlBot do
     assert_gem_file "hello/something-else.json", incoming_content
   end
 
+  it "sets the library_type to manual for a wrapper gem" do
+    incoming_content = <<~CONTENT
+      {
+          "library_type": "unknown",
+          "ruby-rulez": "yeah!"
+      }
+    CONTENT
+    resulting_content = <<~CONTENT
+      {
+          "library_type": "GAPIC_MANUAL",
+          "ruby-rulez": "yeah!"
+      }
+    CONTENT
+
+    create_staging_file "hello/.repo-metadata.json", incoming_content
+
+    invoke_owlbot
+
+    assert_gem_file "hello/.repo-metadata.json", resulting_content
+  end
+
+  describe "versioned gem name" do
+    let(:gem_name) { "my-gem-v1" }
+
+    it "sets the library_type to auto if there are no handwritten files" do
+      incoming_content = <<~CONTENT
+        {
+            "library_type": "unknown",
+            "ruby-rulez": "yeah!"
+        }
+      CONTENT
+      resulting_content = <<~CONTENT
+        {
+            "library_type": "GAPIC_AUTO",
+            "ruby-rulez": "yeah!"
+        }
+      CONTENT
+
+      create_staging_file "hello/.repo-metadata.json", incoming_content
+
+      invoke_owlbot
+
+      assert_gem_file "hello/.repo-metadata.json", resulting_content
+    end
+
+    it "sets the library_type to auto if there are handwritten files" do
+      incoming_content = <<~CONTENT
+        {
+            "library_type": "unknown",
+            "ruby-rulez": "yeah!"
+        }
+      CONTENT
+      resulting_content = <<~CONTENT
+        {
+            "library_type": "GAPIC_COMBO",
+            "ruby-rulez": "yeah!"
+        }
+      CONTENT
+
+      create_staging_file "hello/.repo-metadata.json", incoming_content
+      create_existing_manifest static: ["lib/foo/bar.rb"]
+
+      invoke_owlbot
+
+      assert_gem_file "hello/.repo-metadata.json", resulting_content
+    end
+  end
+
   it "preserves gem version field while allowing changes to api version field" do
     orig_content = <<~CONTENT
       {


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-ruby/pull/19265 notes that some generated Ruby clients have the wrong `library_type` in the `.repo-metadata.json`. This file is generated, but the correct value cannot be determined conclusively by the generator because it doesn't know whether there are partial gapics (which would distinguish between `GAPIC_AUTO` and `GAPIC_COMBO` types). So we push this logic into the OwlBot postprocessor, which does know (based on the owlbot manifest) whether there are handwritten partial gapic files in the library.