### PR TITLE
fix(rad): Clean up before building rad, and fix a corner case crash

### DIFF
--- a/toys/release/.data/rad-yard-templates/default/layout/yaml/method.rb
+++ b/toys/release/.data/rad-yard-templates/default/layout/yaml/method.rb
@@ -231,7 +231,7 @@ def tag_content tag
   entry = "- description: \""
   entry += "#{bold tag.name} " if tag.name && !tag.name.empty?
   entry += "(#{types.join ", "})" unless types.empty?
-  entry += " — #{pre_format tag.text}" unless tag.text.empty?
+  entry += " — #{pre_format tag.text}" if tag.text && !tag.text.empty?
   entry += "\""
   entry
 end

--- a/toys/release/build-rad.rb
+++ b/toys/release/build-rad.rb
@@ -17,18 +17,23 @@
 desc "Build cloud-rad yardoc"
 
 flag :bundle
-flag :yardopts, "--yardopts=PATH", default: ".yardopts"
+flag :yardopts, "--yardopts=PATH"
 flag :gem_name, "--gem-name=NAME"
 flag :friendly_api_name, "--friendly-api-name=NAME"
 
 include :exec, e: true
 include :gems, on_missing: :install
+include :fileutils
 
 def run
   unless gem_name
     logger.error "--gem-name argument is required"
     exit 1
   end
+  set :yardopts, (File.file?(".yardopts-cloudrad") ? ".yardopts-cloudrad" : ".yardopts") unless yardopts
+  logger.info "Reading yardopts from #{yardopts}"
+  rm_rf ".yardoc"
+  rm_rf "doc"
   unless bundle
     gem "yard", "~> 0.9", ">= 0.9.26"
     gem "redcarpet", "~> 3.5", ">= 3.5.1"


### PR DESCRIPTION
* The `release build-rad` tool deletes the `doc` and `.yardoc` directories before executing yard, to ensure no leakage from earlier runs. This should prevent html files from normal yard runs from getting into docfx output for cloud-rad
* The `release build-rad` tool defaults yardopts to `.yardopts-cloudrad` if it exists.
* Fixed a rare crash in the cloud-rad template that appeared in the pubsub veneer.
