### PR TITLE
feat(gas): Implement protobuf kokoro trigger

### DIFF
--- a/.kokoro/gas/trigger-protobuf.cfg
+++ b/.kokoro/gas/trigger-protobuf.cfg
@@ -1,0 +1,50 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Build logs will be here
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.xml"
+  }
+}
+
+# Download Ruby-cloud resources
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/google-cloud-ruby"
+
+# Download trampoline resources
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
+
+# Download artifacts from placer
+gfile_resources: "/placer/prod/home/protobuf-build/release"
+
+# Use the trampoline script to run in docker.
+build_file: "ruby-common-tools/.kokoro/trampoline_v2.sh"
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/release"
+}
+
+# Entrypoint
+env_vars: {
+  key: "TRAMPOLINE_BUILD_FILE"
+  value: ".kokoro/gas/trigger.sh"
+}
+
+# List of binary platforms for protobuf builds, colon-delimited.
+env_vars: {
+  key: "GAS_PLATFORMS"
+  value: "arm64-darwin:x64-mingw-ucrt:x64-mingw32:x86-linux:x86-mingw32:x86_64-darwin:x86_64-linux"
+}
+
+# List of minor Ruby versions for protobuf builds, colon-delimited.
+env_vars: {
+  key: "GAS_RUBY_VERSIONS"
+  value: "2.6:2.7:3.0:3.1:3.2"
+}
+
+# Path to the RubyGems API key file for the protobuf account.
+env_vars: {
+  key: "GAS_RUBYGEMS_KEY_FILE"
+  value: "rubygems-token-protobuf.txt"
+}

--- a/.kokoro/gas/trigger.sh
+++ b/.kokoro/gas/trigger.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# Install gems in the user directory because the default install directory
+# is in a read-only location.
+export GEM_HOME=$HOME/.gem
+export PATH=$GEM_HOME/bin:$PATH
+
+gem install --no-document toys:0.14.4
+toys gas kokoro-trigger -v

--- a/gas/.toys/gas/.test/test_kokoro_trigger.rb
+++ b/gas/.toys/gas/.test/test_kokoro_trigger.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "fileutils"
+require "tmpdir"
+require "toys/utils/exec"
+require "toys/utils/gems"
+require_relative "../.preload"
+
+describe "gas kokoro-trigger" do
+  include Toys::Testing
+
+  Toys::Utils::Gems.activate "gems", Gas::GEMS_VERSION
+  require "gems"
+
+  toys_custom_paths File.dirname File.dirname __dir__
+  toys_include_builtins false
+
+  let(:exec_service) { Toys::Utils::Exec.new }
+  let(:workspace_dir) { Dir.mktmpdir }
+  let(:gem_platforms) do
+    [
+      "arm64-darwin",
+      "x64-mingw-ucrt",
+      "x64-mingw32",
+      "x86-linux",
+      "x86-mingw32",
+      "x86_64-darwin",
+      "x86_64-linux"
+    ]
+  end
+  let(:ruby_versions) { ["2.7", "3.0", "3.1", "3.2"] }
+  let(:gem_and_version) { "google-protobuf-3.21.12" }
+  let(:protobuf_env) do
+    {
+      "KOKORO_GFILE_DIR" => __dir__,
+      "GAS_SOURCE_GEM" => "data/#{gem_and_version}.gem",
+      "GAS_ADDITIONAL_GEMS" => "data2/fake-gem-1.0.gem:data2/fake-gem-2.0.gem",
+      "GAS_PLATFORMS" => gem_platforms.join(":"),
+      "GAS_RUBY_VERSIONS" => ruby_versions.join(":"),
+      "GAS_RUBYGEMS_KEY_FILE" => "data2/keyfile.txt",
+      "GAS_WORKSPACE_DIR" => workspace_dir
+    }
+  end
+  let(:excluded_versions) do
+    {
+      "x64-mingw32" => ["3.1", "3.2"],
+      "x64-mingw-ucrt" => ["2.7", "3.0"]
+    }
+  end
+
+  def temp_set_env hash
+    old_env = hash.to_h do |key, val|
+      old_val = ENV[key]
+      ENV[key] = val
+      [key, old_val]
+    end
+    begin
+      yield
+    ensure
+      old_env.each do |key, val|
+        ENV[key] = val
+      end
+    end
+  end
+
+  def quiet_trigger noisy: false
+    result = 0
+    out = err = nil
+    block = proc do
+      result = toys_run_tool ["gas", "kokoro-trigger", "-v"]
+    end
+    if noisy
+      block.call
+    else
+      out, err = capture_subprocess_io(&block)
+    end
+    unless result.zero?
+      puts out
+      puts err
+      flunk "Failed to run gas kokoro-trigger: result = #{result}"
+    end
+  end
+
+  after do
+    Gems.reset
+    FileUtils.rm_rf workspace_dir
+  end
+
+  it "runs on a protobuf release" do
+    found_content = []
+    temp_set_env protobuf_env do
+      fake_push = proc do |file|
+        found_content << file.read
+        file.close
+      end
+      Gems.stub :push, fake_push do
+        quiet_trigger noisy: true
+      end
+    end
+
+    # Make sure we used the correct RubyGems API token
+    assert_equal "0123456789abcdef", Gems.key
+
+    # Make sure we "published" the expected gems
+    assert_equal 10, found_content.size
+    assert_includes found_content, "fake gem 1.0"
+    assert_includes found_content, "fake gem 2.0"
+
+    # Make sure we built the expected gems
+    Dir.chdir "#{workspace_dir}/#{gem_and_version}/pkg/" do
+      gem_platforms.each do |platform|
+        assert File.exist? "#{gem_and_version}-#{platform}.gem"
+        FileUtils.rm_r "#{gem_and_version}-#{platform}"
+        exec_service.exec ["gem", "unpack", "#{gem_and_version}-#{platform}.gem"], out: :null
+        suffix = platform.include?("darwin") ? "bundle" : "so"
+        actual_ruby_versions = ruby_versions - excluded_versions.fetch(platform, [])
+        actual_ruby_versions.each do |ruby|
+          assert File.exist? "#{gem_and_version}-#{platform}/lib/google/#{ruby}/protobuf_c.#{suffix}"
+        end
+      end
+    end
+  end
+end

--- a/gas/.toys/gas/kokoro-trigger.rb
+++ b/gas/.toys/gas/kokoro-trigger.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+desc "Script for a Kokoro-based trigger"
+
+long_desc \
+  "This tool is designed to be called as the entrypoint for a Kokoro job " \
+    "that participates in a release pipeline. It reads its input from " \
+    "environment variables, and executes build and publish non-interactively.",
+  "",
+  "The following environment variables should be set when invoking:",
+  "",
+  "KOKORO_GFILE_DIR - Base directory for gfile inclusion. Should be set by " \
+    "the Kokoro environment. (Required.)",
+  "GAS_SOURCE_GEM - The gfile path (i.e. relative to KOKORO_GFILE_DIR) for " \
+    "the source gem input. Required.",
+  "GAS_ADDITIONAL_GEMS - The gfile paths for any additional gems that do " \
+    "not need further building but should be released. Multiple gem paths " \
+    "should be delimited by colons. Optional.",
+  "GAS_PLATFORMS - Colon-delimited list of gem platforms that should be " \
+    "built into binary gems. Optional.",
+  "GAS_RUBY_VERSIONS - Colon-delimited list of Ruby versions that should " \
+    "be built against. Optional.",
+  "GAS_RUBYGEMS_KEY_FILE - The gfile path to a file that contains the API " \
+    "token for Rubygems, to use for publication. Required."
+
+include :fileutils
+include :exec, e: true
+
+# Entrypoint
+def run
+  cd context_directory
+  read_input
+  analyze_source
+  build_binaries
+  upload_gems
+end
+
+# Read input and configuration from the environment.
+# See the long description for details.
+def read_input
+  gfile_dir = ENV["KOKORO_GFILE_DIR"]
+  @source_gem = File.join gfile_dir, ENV["GAS_SOURCE_GEM"]
+  @additional_gems = ENV["GAS_ADDITIONAL_GEMS"].to_s.split(":").map { |path| File.join gfile_dir, path }
+  @platforms = ENV["GAS_PLATFORMS"].tr ":", ","
+  @ruby_versions = ENV["GAS_RUBY_VERSIONS"].tr ":", ","
+  @rubygems_key_file = File.join gfile_dir, ENV["GAS_RUBYGEMS_KEY_FILE"]
+  @dry_run = !ENV["GAS_DRY_RUN"].to_s.empty?
+  @workspace_dir = ENV["GAS_WORKSPACE_DIR"] || "workspace"
+end
+
+# Read the gem name and version from the source gem metadata
+def analyze_source
+  require "yaml"
+  rm_rf @workspace_dir
+  mkdir_p @workspace_dir
+  cd @workspace_dir do
+    exec ["gem", "unpack", "--spec", @source_gem]
+    gemspec_file = Dir.glob("*.gemspec").first
+    permitted_classes = [Gem::Specification, Gem::Dependency, Gem::Version, Gem::Requirement, Time, Symbol]
+    gemspec = YAML.load_file gemspec_file, permitted_classes: permitted_classes
+    @gem_name = gemspec.name
+    @gem_version = gemspec.version.to_s
+    raise "Wrong platform for source gem!" unless gemspec.platform == "ruby"
+  end
+end
+
+# Invoke gas build to build .gem files from the provided source gem
+def build_binaries
+  tool = [
+    "gas", "build",
+    *verbosity_flags, "--yes",
+    "--clean",
+    "--workspace-dir", @workspace_dir,
+    "--platform", @platforms,
+    "--ruby", @ruby_versions,
+    "--source-gem", @source_gem,
+    @gem_name, @gem_version
+  ]
+  result = cli.run tool
+  unless result.zero?
+    logger.fatal "gas build failed with result #{result}"
+    exit result
+  end
+end
+
+# Invoke gas publish to publish all gems to rubygems.org, unless dry run has
+# been requested
+def upload_gems
+  pkg_dir = File.join @workspace_dir, "#{@gem_name}-#{@gem_version}", "pkg"
+  tool = [
+    "gas", "publish",
+    *verbosity_flags, "--yes",
+    "--force",
+    "--rubygems-key-file", @rubygems_key_file,
+    pkg_dir, @source_gem, *@additional_gems
+  ]
+  tool << "--dry-run" if @dry_run
+  result = cli.run tool
+  unless result.zero?
+    logger.fatal "gas publish failed with result #{result}"
+    exit result
+  end
+end


### PR DESCRIPTION
This is the Trigger component for the Ruby Gems-As-a-Service mechanism. It implements a Kokoro job that can be invoked from a client CI/CD pipeline, receives the input, and orchestrates the builder and publisher.

Note: this PR may include more than one commit. If so, only the latest commit is unique to this PR; earlier commits are from earlier PRs that this PR is dependent on. Reviewers can restrict comments to the latest commit.

Includes the following:

* `gas/.toys/gas/kokoro-trigger.rb`: The `toys gas kokoro-trigger` implementation itself.
* `.kokoro/gas/trigger-protobuf.cfg`: Kokoro build configuration for Protobuf. In particular, includes default values for the list of platforms and ruby versions to build.
* `.kokoro/gas/trigger.sh`: Kokoro entrypoint (runs within the docker container).
