### PR TITLE
fix(owlbot): Remove ruby-doc.org link hack

### DIFF
--- a/owlbot-postprocessor/lib/owlbot/common_modifiers.rb
+++ b/owlbot-postprocessor/lib/owlbot/common_modifiers.rb
@@ -135,22 +135,6 @@ module OwlBot
     end
 
     ##
-    # Temporary fix for ruby-doc.org links that broke with the December 2022
-    # redesign of of the site.
-    #
-    # @param name [String] Optional name for the modifier to add. Defaults to
-    #     `"fix_rubydoc_org_links"`.
-    #
-    def fix_rubydoc_org_links path: nil, name: nil
-      path ||= [/\.md$/]
-      name ||= "fix_rubydoc_org_links"
-      modifier path: path, name: name do |src, _dest|
-        src&.gsub %r{https://ruby-doc\.org/stdlib/libdoc/(\w+)/rdoc/([\w/]+)\.html},
-                  "https://ruby-doc.org/current/stdlibs/\\1/\\2.html"
-      end
-    end
-
-    ##
     # Install the default modifiers. This includes:
     #
     # * A modifier named `"preserve_existing_copyright_years"` which ensures
@@ -184,9 +168,6 @@ module OwlBot
                                     name: "prevent_overwrite_of_existing_changelog_file"
       prevent_overwrite_of_existing "lib/#{@impl.gem_name.tr '-', '/'}/version.rb",
                                     name: "prevent_overwrite_of_existing_gem_version_file"
-      # TODO: Remove this when we're sure the generator isn't generating any
-      # old links.
-      fix_rubydoc_org_links
     end
   end
 end

--- a/owlbot-postprocessor/test/test_owlbot.rb
+++ b/owlbot-postprocessor/test/test_owlbot.rb
@@ -293,21 +293,6 @@ describe OwlBot do
     assert_gem_file "hello/.repo-metadata.json", resulting_content
   end
 
-  it "fixes ruby-doc.org links" do
-    incoming_content = <<~CONTENT
-      Link [here](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) for a good time!
-    CONTENT
-    resulting_content = <<~CONTENT
-      Link [here](https://ruby-doc.org/current/stdlibs/logger/Logger.html) for a good time!
-    CONTENT
-
-    create_staging_file "hello/README.md", incoming_content
-
-    invoke_owlbot
-
-    assert_gem_file "hello/README.md", resulting_content
-  end
-
   describe "versioned gem name" do
     let(:gem_name) { "my-gem-v1" }
 


### PR DESCRIPTION
This hack is no longer necessary as the generator has been fixed upstream (https://github.com/googleapis/gapic-generator-ruby/pull/926)