### PR TITLE
fix(rad): Fix crash when a param doesn't specify a type

### DIFF
--- a/toys/release/.data/rad-yard-templates/default/layout/yaml/method.rb
+++ b/toys/release/.data/rad-yard-templates/default/layout/yaml/method.rb
@@ -150,7 +150,7 @@ def arg_text method, params, indent
     name = arg.name
     name = "value" if name.nil? || name.empty?
     entry = "- description: \"#{bold name}"
-    types = arg.types.map { |type| link_objects type }
+    types = arg.types.to_a.map { |type| link_objects type }
     entry += " (#{types.join ", "})" unless types.empty?
     default_value ||= canonical_method.parameters.select { |n| n[0] == "#{name}:" }.last
     if default_value && default_value.last

--- a/toys/release/perform.rb
+++ b/toys/release/perform.rb
@@ -260,7 +260,11 @@ class Performer
         return
       end
       logger.info "**** Starting publish_rad for #{gem_name}"
-      cli.run(*tool_name[0..-2], "build-rad", "--gem-name", gem_name, "--friendly-api-name", friendly_api_name)
+      result = cli.run(*tool_name[0..-2], "build-rad", "--gem-name", gem_name, "--friendly-api-name", friendly_api_name)
+      unless result.zero?
+        logger.error "**** build-rad failed! Aborting publish_rad."
+        return
+      end
       run_docuploader staging_bucket: rad_staging_bucket,
                       extra_docuploader_args: ["--destination-prefix", "docfx"],
                       dry_run: dry_run

--- a/toys/release/please.rb
+++ b/toys/release/please.rb
@@ -176,7 +176,7 @@ def package_version package_name, dir, version_path
       proc do
         Dir.chdir dir do
           spec = Gem::Specification.load "#{package_name}.gemspec"
-          puts spec.version.to_s
+          puts spec.version
         end
       end
     end


### PR DESCRIPTION
Fixes https://github.com/googleapis/doc-pipeline/issues/423

The issue, apparently, is that when a `@param` tag is _not_ annotated with a type, the `types` field is set to `nil`, which causes a crash here because we're calling `map` on the result. Generally, we always include a type for a `@param` tag, even if it's just `[Object]`, but it looks like one slipped through in https://github.com/googleapis/google-cloud-ruby/pull/21002/files (dataset.rb line 990). I'll fix that separately, but for docgen, we can make it robust against that case by calling `to_a` on the `types` to map `nil` to the empty array before calling `map` on it.

Also updates the release script so failures in build-rad cause a full abort of publish-rad rather than letting it attempt to publish an incomplete tarball.