### PR TITLE
chore: update trigger-protobuf.cfg to drop ruby 2.6 for protobuf

### DIFF
--- a/.kokoro/gas/trigger-protobuf.cfg
+++ b/.kokoro/gas/trigger-protobuf.cfg
@@ -37,7 +37,7 @@ env_vars: {
 # List of minor Ruby versions for protobuf builds, colon-delimited.
 env_vars: {
   key: "GAS_RUBY_VERSIONS"
-  value: "2.6:2.7:3.0:3.1:3.2"
+  value: "2.7:3.0:3.1:3.2"
 }
 
 # Path to the RubyGems API key file for the protobuf account.


### PR DESCRIPTION
Ruby 2.6 has been dropped from protobuf's support window per https://cloud.google.com/ruby/getting-started/supported-ruby-versions?_ga=2.53600104.-1733366221.1688696481

This is needed for Ruby release for v24.0-rc1