### PR TITLE
fix(gas): Update default ruby versions in kokoro jobs to include 3.3

### DIFF
--- a/.kokoro/gas/trigger-cloud.cfg
+++ b/.kokoro/gas/trigger-cloud.cfg
@@ -28,16 +28,16 @@ env_vars: {
   value: ".kokoro/gas/trigger.sh"
 }
 
-# List of binary platforms for protobuf builds, colon-delimited.
+# List of binary platforms for ruby-cloud builds, colon-delimited.
 env_vars: {
   key: "GAS_PLATFORMS"
   value: "aarch64-linux:arm64-darwin:x64-mingw-ucrt:x64-mingw32:x86-linux:x86-mingw32:x86_64-darwin:x86_64-linux"
 }
 
-# List of minor Ruby versions for protobuf builds, colon-delimited.
+# List of minor Ruby versions for ruby-cloud builds, colon-delimited.
 env_vars: {
   key: "GAS_RUBY_VERSIONS"
-  value: "2.6:2.7:3.0:3.1:3.2"
+  value: "2.7:3.0:3.1:3.2:3.3"
 }
 
 # Path to the RubyGems API key file for the google-cloud account.

--- a/.kokoro/gas/trigger-generic.cfg
+++ b/.kokoro/gas/trigger-generic.cfg
@@ -28,16 +28,16 @@ env_vars: {
   value: ".kokoro/gas/trigger.sh"
 }
 
-# List of binary platforms for protobuf builds, colon-delimited.
+# List of binary platforms for generic builds, colon-delimited.
 env_vars: {
   key: "GAS_PLATFORMS"
   value: "aarch64-linux:arm64-darwin:x64-mingw-ucrt:x64-mingw32:x86-linux:x86-mingw32:x86_64-darwin:x86_64-linux"
 }
 
-# List of minor Ruby versions for protobuf builds, colon-delimited.
+# List of minor Ruby versions for generic builds, colon-delimited.
 env_vars: {
   key: "GAS_RUBY_VERSIONS"
-  value: "2.6:2.7:3.0:3.1:3.2"
+  value: "2.7:3.0:3.1:3.2:3.3"
 }
 
 # This must be set when invoking the job.

--- a/.kokoro/gas/trigger-protobuf.cfg
+++ b/.kokoro/gas/trigger-protobuf.cfg
@@ -37,7 +37,7 @@ env_vars: {
 # List of minor Ruby versions for protobuf builds, colon-delimited.
 env_vars: {
   key: "GAS_RUBY_VERSIONS"
-  value: "2.7:3.0:3.1:3.2"
+  value: "2.7:3.0:3.1:3.2:3.3"
 }
 
 # Path to the RubyGems API key file for the protobuf account.


### PR DESCRIPTION
Supersedes #286