### PR TITLE
fix(gas): Get rubygems key from keystore

### DIFF
--- a/.kokoro/gas/trigger-cloud.cfg
+++ b/.kokoro/gas/trigger-cloud.cfg
@@ -37,7 +37,18 @@ env_vars: {
 # Path to the RubyGems API key file for the google-cloud account.
 env_vars: {
   key: "GAS_RUBYGEMS_KEY_FILE"
-  value: "rubygems-token-cloud.txt"
+  value: "73713_rubygems-publish-key"
+}
+
+# Pick up Rubygems key from internal keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "rubygems-publish-key"
+      backend: "blade:keystore-fastconfigpush"
+    }
+  }
 }
 
 # Store the packages uploaded to rubygems.org, which

--- a/.kokoro/gas/trigger-generic.cfg
+++ b/.kokoro/gas/trigger-generic.cfg
@@ -7,19 +7,13 @@ action {
   }
 }
 
-# Download Ruby-cloud resources
-gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/google-cloud-ruby"
-
-# Download trampoline resources
-gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
-
 # Use the trampoline script to run in docker.
 build_file: "ruby-common-tools/.kokoro/gas/trigger_trampoline.sh"
 
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/release"
+  value: "us-central1-docker.pkg.dev/cloud-sdk-release-custom-pool/release-images/ruby-multi"
 }
 
 # Entrypoint
@@ -43,7 +37,18 @@ env_vars: {
 # This must be set when invoking the job.
 env_vars: {
   key: "GAS_RUBYGEMS_KEY_FILE"
-  value: "rubygems-token-generic.txt"
+  value: "73713_rubygems-publish-key"
+}
+
+# Pick up Rubygems key from internal keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "rubygems-publish-key"
+      backend: "blade:keystore-fastconfigpush"
+    }
+  }
 }
 
 # Store the packages uploaded to rubygems.org, which

--- a/.kokoro/gas/trigger-protobuf.cfg
+++ b/.kokoro/gas/trigger-protobuf.cfg
@@ -37,7 +37,18 @@ env_vars: {
 # Path to the RubyGems API key file for the protobuf account.
 env_vars: {
   key: "GAS_RUBYGEMS_KEY_FILE"
-  value: "rubygems-token-protobuf.txt"
+  value: "73713_rubygems-token-protobuf"
+}
+
+# Pick up Rubygems key from internal keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "rubygems-token-protobuf"
+      backend: "blade:keystore-fastconfigpush"
+    }
+  }
 }
 
 # Store the packages uploaded to rubygems.org, which

--- a/gas/.toys/gas/.test/test_kokoro_trigger.rb
+++ b/gas/.toys/gas/.test/test_kokoro_trigger.rb
@@ -48,11 +48,12 @@ describe "gas kokoro-trigger" do
   let(:protobuf_env) do
     {
       "KOKORO_GFILE_DIR" => __dir__,
+      "KOKORO_KEYSTORE_DIR" => "#{__dir__}/data2",
       "GAS_SOURCE_GEM" => "data32",
       "GAS_ADDITIONAL_GEMS" => "data2",
       "GAS_PLATFORMS" => gem_platforms.join(":"),
       "GAS_RUBY_VERSIONS" => ruby_versions.join(":"),
-      "GAS_RUBYGEMS_KEY_FILE" => "data2/keyfile.txt",
+      "GAS_RUBYGEMS_KEY_FILE" => "keyfile.txt",
       "GAS_WORKSPACE_DIR" => workspace_dir,
       "GAS_ARTIFACTS_DIR" => artifacts_dir
     }

--- a/gas/.toys/gas/kokoro-trigger.rb
+++ b/gas/.toys/gas/kokoro-trigger.rb
@@ -25,6 +25,8 @@ long_desc \
   "",
   "KOKORO_GFILE_DIR - Base directory for gfile inclusion. Should be set by " \
     "the Kokoro environment. (Required.)",
+  "KOKORO_KEYSTORE_DIR - Base directory for keystore data. Should be set by " \
+    "the Kokoro environment. (Required.)",
   "GAS_SOURCE_GEM - The gfile path (i.e. relative to KOKORO_GFILE_DIR) for " \
     "the source gem input. If a directory is provided, it must contain, " \
     "recursively, exactly one source gem. Required.",
@@ -36,8 +38,9 @@ long_desc \
     "built into binary gems. Optional.",
   "GAS_RUBY_VERSIONS - Colon-delimited list of Ruby versions that should " \
     "be built against. Optional.",
-  "GAS_RUBYGEMS_KEY_FILE - The gfile path to a file that contains the API " \
-    "token for Rubygems, to use for publication. Required."
+  "GAS_RUBYGEMS_KEY_FILE - The keystore path to a file that contains the API " \
+    "token for Rubygems, to use for publication. Should be in the form " \
+    "{keystoreConfigId}_{keyName}. Required."
 
 include :fileutils
 include :exec, e: true
@@ -56,6 +59,7 @@ end
 # See the long description for details.
 def read_input
   gfile_dir = ENV["KOKORO_GFILE_DIR"]
+  keystore_dir = ENV["KOKORO_KEYSTORE_DIR"]
   @source_gem = File.join gfile_dir, ENV["GAS_SOURCE_GEM"]
   if File.directory? @source_gem
     candidates = Dir.glob "#{@source_gem}/**/*.gem"
@@ -65,7 +69,7 @@ def read_input
   @additional_gems = ENV["GAS_ADDITIONAL_GEMS"].to_s.split(":").map { |path| File.join gfile_dir, path }
   @platforms = ENV["GAS_PLATFORMS"].tr ":", ","
   @ruby_versions = ENV["GAS_RUBY_VERSIONS"].tr ":", ","
-  @rubygems_key_file = File.join gfile_dir, ENV["GAS_RUBYGEMS_KEY_FILE"]
+  @rubygems_key_file = File.join keystore_dir, ENV["GAS_RUBYGEMS_KEY_FILE"]
   @dry_run = !ENV["GAS_DRY_RUN"].to_s.empty?
   @workspace_dir = ENV["GAS_WORKSPACE_DIR"] || "workspace"
   @artifacts_dir = ENV["GAS_ARTIFACTS_DIR"] || "artifacts"

--- a/toys/release/perform.rb
+++ b/toys/release/perform.rb
@@ -79,14 +79,6 @@ end
 def load_env
   kokoro_gfile_dir = ENV["KOKORO_GFILE_DIR"]
   if kokoro_gfile_dir
-    # TEMP: Remove after all references to this file are removed for all repos
-    env_vars_path = File.join kokoro_gfile_dir, "ruby_env_vars.json"
-    if File.file? env_vars_path
-      env_vars = JSON.parse File.read env_vars_path
-      env_vars.each { |k, v| ENV[k] ||= v }
-      logger.info "Read environment from GCS"
-    end
-
     docuploader_service_account_path = File.join kokoro_gfile_dir, "secret_manager", "docuploader_service_account"
     if File.file? docuploader_service_account_path
       ENV["DOCUPLOADER_CREDENTIALS"] ||= docuploader_service_account_path


### PR DESCRIPTION
Transitions the GAS kokoro jobs (notably the protobuf release job) to get their Rubygems keys from keystore instead of from GCS. This repurposes the existing `GAS_RUBYGEMS_KEY_FILE` environment variable to specify the keystore file path (relative to `KOKORO_KEYSTORE_DIR`) instead of a gfile-based path (relative to `KOKORO_GFILE_DIR`) so that we don't have to define a new environment variable through the entire Kokoro config system.

This should not be merged until the corresponding keystore key `rubygems-token-protobuf` has been pushed (internal cl/697837917) and made accessible to the jobs (internal cl/697841636).