### PR TITLE
Drop Ruby 3.0

### DIFF
--- a/.kokoro/gas/trigger-protobuf.cfg
+++ b/.kokoro/gas/trigger-protobuf.cfg
@@ -31,7 +31,7 @@ env_vars: {
 # List of minor Ruby versions for protobuf builds, colon-delimited.
 env_vars: {
   key: "GAS_RUBY_VERSIONS"
-  value: "3.0:3.1:3.2:3.3:3.4"
+  value: "3.1:3.2:3.3:3.4"
 }
 
 # Path to the RubyGems API key file for the protobuf account.


### PR DESCRIPTION
chore: Drop Ruby 3.0 from the set of Ruby language versions

BREAKING CHANGE: Drops Ruby 3.0 support