### PR TITLE
fix(toys-gapic): Workaround for stackoverflow denying linkinator requests

### DIFF
--- a/toys/gapic/linkinator.rb
+++ b/toys/gapic/linkinator.rb
@@ -49,7 +49,8 @@ def determine_skips gem_name
     "\\w+\\.md$",
     "^https://rubygems\\.org/gems/#{wrapper_gem_name}",
     "^https://cloud\\.google\\.com/ruby/docs/reference/#{gem_name}/latest$",
-    "^https://rubydoc\\.info/gems/#{gem_name}"
+    "^https://rubydoc\\.info/gems/#{gem_name}",
+    "^https?://stackoverflow\\.com/questions/tagged/google-cloud-platform\\+ruby$"
   ]
   if gem_name == wrapper_gem_name
     skip_regexes << "^https://cloud\\.google\\.com/ruby/docs/reference/#{gem_name}-v\\d\\w*/latest$"


### PR DESCRIPTION
StackOverflow recently has been returning 403 errors for Linkinator probes. This is a workaround for the common ruby link we use.