### PR TITLE
fix: Remove incompatible gh remote flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            ruby: "3.1"
-            build: true
-            jobs: "--only --test"
-          - os: ubuntu-latest
             ruby: "3.2"
             build: true
             jobs: "--only --test"

--- a/.toys/ci.rb
+++ b/.toys/ci.rb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-toys_version! "~> 0.15"
+toys_version! "~> 0.21"
 
 desc "Run CI checks"
 
@@ -89,7 +89,7 @@ def run_test
           next
         end
       end
-      result = exec_separate_tool ["test", "--minitest-mock"], name: "Tests in #{dir}"
+      result = exec_separate_tool ["test"], name: "Tests in #{dir}"
       if result.success?
         puts "PASSED: #{name}", :bold, :green
       else

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "google-style", "~> 1.30.1"
+gem "google-style", "~> 1.32.0"

--- a/owlbot-postprocessor/Gemfile
+++ b/owlbot-postprocessor/Gemfile
@@ -14,8 +14,8 @@
 
 source "https://rubygems.org"
 
-gem "google-style", "~> 1.31.0"
-gem "minitest", "~> 5.16"
-gem "minitest-focus", "~> 1.3"
-gem "minitest-rg", "~> 5.2"
-gem "toys-core", "~> 0.15"
+gem "google-style", "~> 1.32.0"
+gem "minitest", "~> 6.0.2"
+gem "minitest-focus", "~> 1.4"
+gem "minitest-rg", "~> 5.3"
+gem "toys-core", "~> 0.21"

--- a/owlbot-postprocessor/test/test_owlbot.rb
+++ b/owlbot-postprocessor/test/test_owlbot.rb
@@ -720,7 +720,7 @@ describe OwlBot do
     it "runs toys" do
       create_gem_file "Gemfile", <<~RUBY
         source "https://rubygems.org"
-        gem "minitest", "~> 5.14"
+        gem "minitest", "~> 6.0.2"
       RUBY
       create_gem_file ".toys.rb", <<~RUBY
         tool "foo" do

--- a/toys/yoshi/.lib/yoshi/utils.rb
+++ b/toys/yoshi/.lib/yoshi/utils.rb
@@ -140,7 +140,7 @@ module Yoshi
     def gh_ensure_fork remote: nil
       git_verify_binary
       gh_verify_binary
-      @context.exec ["gh", "repo", "fork", gh_repo_full_name, "--remote=false", "--clone=false"], e: true
+      @context.exec ["gh", "repo", "fork", gh_repo_full_name, "--clone=false"], e: true
       @context.exec ["gh", "repo", "sync", gh_fork_full_name], e: true
       if remote && gh_cur_token
         unless context.exec(["git", "remote", "get-url", remote], e: false, out: :null, err: :null).success?


### PR DESCRIPTION
There is a new restriction making --remote mutually exclusive with a specified repository argument. The flag used to be silently ignored.

The change was introduced in GitHub CLI v2.88.0 https://github.com/cli/cli/releases/tag/v2.88.0

chore: Remove Ruby 3.1 from CI
chore: Updates to toys minitest flag

New change related to minitest-mock in `toys` https://github.com/dazuma/toys/releases/tag/toys/v0.20.0