### PR TITLE
feat(owlbot): update Ruby version to 4.0.3

### DIFF
--- a/owlbot-postprocessor/Dockerfile
+++ b/owlbot-postprocessor/Dockerfile
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ruby:3.4.5-bookworm
+FROM ruby:4.0.3-bookworm
 RUN apt-get update \
     && apt-get -y upgrade \
     && apt-get -y autoremove \
     && apt-get -y autoclean
 RUN mkdir /ruby-postprocessor \
-    && gem install toys:0.15.6 rexml:3.4.0
+    && gem install toys:0.21.0 rexml:3.4.4
 WORKDIR /ruby-postprocessor
 COPY lib/*.rb /ruby-postprocessor/
 COPY lib/owlbot /ruby-postprocessor/owlbot


### PR DESCRIPTION
Verified it via `toys build` and `toys test` in the `owlbot-postprocessor` directory directly.