### PR TITLE
chore: Drop support for Ruby 3.1

### DIFF
--- a/.kokoro/gas/trigger-cloud.cfg
+++ b/.kokoro/gas/trigger-cloud.cfg
@@ -31,7 +31,7 @@ env_vars: {
 # List of minor Ruby versions for ruby-cloud builds, colon-delimited.
 env_vars: {
   key: "GAS_RUBY_VERSIONS"
-  value: "3.1:3.2:3.3:3.4"
+  value: "3.2:3.3:3.4:4.0"
 }
 
 # Path to the RubyGems API key file for the google-cloud account.

--- a/.kokoro/gas/trigger-protobuf.cfg
+++ b/.kokoro/gas/trigger-protobuf.cfg
@@ -31,7 +31,7 @@ env_vars: {
 # List of minor Ruby versions for protobuf builds, colon-delimited.
 env_vars: {
   key: "GAS_RUBY_VERSIONS"
-  value: "3.1:3.2:3.3:3.4:4.0"
+  value: "3.2:3.3:3.4:4.0"
 }
 
 # Path to the RubyGems API key file for the protobuf account.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_gem:
   google-style: google-style.yml
 
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
   Exclude:
     - "test-data-generator/resource/**/*"
     - "gas/workspace/**/*"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "google-style", "~> 1.32.0"
+gem "minitest-mock", "~> 5.27"

--- a/gas/.toys/gas/.preload.rb
+++ b/gas/.toys/gas/.preload.rb
@@ -37,7 +37,7 @@ module Gas
   ##
   # Ruby versions to build if no versions are specified on the command line
   #
-  DEFAULT_RUBIES = ["3.1", "3.2", "3.3", "3.4", "4.0"]
+  DEFAULT_RUBIES = ["3.2", "3.3", "3.4", "4.0"]
 
   ##
   # Version of the Gems gem to install

--- a/gas/.toys/gas/.test/test_build.rb
+++ b/gas/.toys/gas/.test/test_build.rb
@@ -50,10 +50,10 @@ describe "gas build" do
   # See https://github.com/rake-compiler/rake-compiler-dock/issues/189 for details about the issue with
   # this platform and Ruby version combination:
   let(:excluded_combinations) { [["x86-mingw32", "4.0"]] }
-  let(:windows_ruby_versions) { ["3.1", "4.0"] }
+  let(:windows_ruby_versions) { ["3.2", "4.0"] }
   let(:host_platform) { "#{`uname -m`.strip}-#{`uname -s`.strip.downcase}" }
   let(:host_ruby_version) { RUBY_VERSION.sub(/^(\d+\.\d+).*$/, "\\1") }
-  let(:multi_rubies) { ["3.1", "3.2", "3.3", "3.4", "4.0" ]}
+  let(:multi_rubies) { ["3.2", "3.3", "3.4", "4.0" ]}
   let(:gem_version_for_multi_rubies) { "4.29.2" }
   let(:platform_for_multi_rubies) { "x86_64-linux-gnu" }
 

--- a/gas/.toys/gas/.test/test_kokoro_trigger.rb
+++ b/gas/.toys/gas/.test/test_kokoro_trigger.rb
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 require "fileutils"
+require "minitest/mock"
 require "tmpdir"
 require "toys/utils/exec"
 require "toys/utils/gems"
@@ -42,7 +43,7 @@ describe "gas kokoro-trigger" do
       "x86_64-linux"
     ]
   end
-  let(:ruby_versions) { ["3.1", "3.2", "3.3", "3.4", "4.0"] }
+  let(:ruby_versions) { ["3.2", "3.3", "3.4", "4.0"] }
   let(:gem_and_version) { "google-protobuf-3.25.2" }
   let(:protobuf_env) do
     {

--- a/gas/.toys/gas/.test/test_publish.rb
+++ b/gas/.toys/gas/.test/test_publish.rb
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "minitest/mock"
 require "toys/utils/gems"
 require_relative "../.preload"
 


### PR DESCRIPTION
chore: Drop support for Ruby 3.1