### PR TITLE
chore: Update trigger-generic.cfg to drop Ruby 3.1 and support 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,15 +41,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v5
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Install Ruby ${{ matrix.ruby }}
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
       with:
         ruby-version: "${{ matrix.ruby }}"
-    - name: Install NodeJS 20.x
-      uses: actions/setup-node@v4
+    - name: Install NodeJS 24.x
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
-        node-version: "20.x"
+        node-version: "24.x"
     - name: Install tools and deps
       shell: bash
       run: "gem install --no-document toys && bundle install"

--- a/.kokoro/gas/trigger-generic.cfg
+++ b/.kokoro/gas/trigger-generic.cfg
@@ -31,7 +31,7 @@ env_vars: {
 # List of minor Ruby versions for generic builds, colon-delimited.
 env_vars: {
   key: "GAS_RUBY_VERSIONS"
-  value: "3.1:3.2:3.3:3.4"
+  value: "3.2:3.3:3.4:4.0"
 }
 
 # This must be set when invoking the job.


### PR DESCRIPTION
chore: Upgrade Node to v24 and pin actions