### PR TITLE
feat: Integrate JUnit XML reporter hooks in shared Toys tasks

### DIFF
--- a/toys/gapic/.toys.rb
+++ b/toys/gapic/.toys.rb
@@ -38,6 +38,34 @@ expand :minitest do |t|
   t.files = "test/**/*_test.rb"
 end
 
+require_relative "junit_helper"
+
+# Reopen the standard minitest "test" task to hook bundle setup, test execution,
+# and code preloading. This injects the JUnit XML test formatter (generating reports at
+# tmp/reports/sponge_log.xml) to track test health and failures on the TestGrid dashboard.
+tool "test" do
+  include GapicJunitHelper
+
+  alias_method :original_bundler_setup, :bundler_setup
+  alias_method :original_run, :run
+
+  def bundler_setup gemfile_path: nil
+    original_bundler_setup gemfile_path: setup_junit_wrapper(gemfile_path: gemfile_path)
+  end
+
+  def run
+    original_run
+  ensure
+    cleanup_junit_wrapper
+  end
+
+  def preload_code
+    original = self[:preload_code]
+    original ? "#{junit_preload_code}\n#{original}" : junit_preload_code
+  end
+end
+
+
 tool "bundle" do
   flag :update, desc: "Update rather than install the bundle"
 

--- a/toys/gapic/integration.rb
+++ b/toys/gapic/integration.rb
@@ -154,3 +154,55 @@ expand :minitest do |t|
   t.use_bundler
   t.files = "acceptance/**/*smoke_test.rb"
 end
+
+require_relative "junit_helper"
+
+# Reopen the internal "_acceptance" integration test runner to inject JUnit XML test
+# formatting (generating reports at tmp/reports/sponge_log.xml). This enables integration
+# test results tracking on the centralized TestGrid dashboard.
+tool "_acceptance" do
+  include GapicJunitHelper
+
+  alias_method :original_bundler_setup, :bundler_setup
+  alias_method :original_run, :run
+
+  def bundler_setup gemfile_path: nil
+    original_bundler_setup gemfile_path: setup_junit_wrapper(gemfile_path: gemfile_path)
+  end
+
+  def run
+    original_run
+  ensure
+    cleanup_junit_wrapper
+  end
+
+  def preload_code
+    original = self[:preload_code]
+    original ? "#{junit_preload_code}\n#{original}" : junit_preload_code
+  end
+end
+
+# Reopen the internal "_smoke" integration test runner to inject JUnit XML test
+# formatting (generating reports at tmp/reports/sponge_log.xml). This enables integration
+# smoke test results tracking on the centralized TestGrid dashboard.
+tool "_smoke" do
+  include GapicJunitHelper
+
+  alias_method :original_bundler_setup, :bundler_setup
+  alias_method :original_run, :run
+
+  def bundler_setup gemfile_path: nil
+    original_bundler_setup gemfile_path: setup_junit_wrapper(gemfile_path: gemfile_path)
+  end
+
+  def run
+    original_run
+  ensure
+    cleanup_junit_wrapper
+  end
+
+  def preload_code
+    original = self[:preload_code]
+    original ? "#{junit_preload_code}\n#{original}" : junit_preload_code
+  end
+end

--- a/toys/gapic/junit_helper.rb
+++ b/toys/gapic/junit_helper.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "fileutils"
+
+##
+# Helper module to automatically format minitest execution output into JUnit XML
+# reports. This enables centralized test result indexing, flake tracing, and
+# build health metrics reporting inside TestGrid dashboards.
+#
+# If a package does not natively declare `minitest-reporters` as a dependency,
+# this helper dynamically wraps the bundle Gemfile at execution time, activates it,
+# and preloads the custom Minitest reporter hook which writes to `tmp/reports/sponge_log.xml`.
+#
+module GapicJunitHelper
+  ##
+  # Dynamically wraps the original Gemfile with a wrapper Gemfile containing
+  # the `minitest-reporters` dependency. This is skipped if the original Gemfile
+  # or lockfile already declares the dependency natively.
+  #
+  # @param gemfile_path [String, nil] Path to original Gemfile
+  # @return [String] Path to active Gemfile (original or wrapper)
+  #
+  def setup_junit_wrapper gemfile_path: nil
+    ctx_dir = context_directory || Dir.getwd
+    original_gemfile = File.expand_path(gemfile_path || "Gemfile", ctx_dir)
+    return original_gemfile unless ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+    return original_gemfile unless File.file? original_gemfile
+
+    # Check if minitest-reporters is already defined natively
+    lockfile = "#{original_gemfile}.lock"
+    has_dep = File.read(original_gemfile).include?("minitest-reporters")
+    has_dep ||= File.read(lockfile).include?("minitest-reporters") if File.file? lockfile
+
+    if has_dep
+      return original_gemfile
+    end
+
+    @wrapper_gemfile = File.join ctx_dir, "Gemfile.junit"
+    wrapper_content = <<~GEMFILE
+      eval_gemfile #{original_gemfile.inspect}
+      gem "minitest-reporters", "~> 1.5.0", require: false
+    GEMFILE
+
+    File.write @wrapper_gemfile, wrapper_content
+    ENV["BUNDLE_GEMFILE"] = @wrapper_gemfile
+    @wrapper_gemfile
+  end
+
+  ##
+  # Cleans up any generated wrapper Gemfile and its lockfile from the directory.
+  #
+  def cleanup_junit_wrapper
+    return unless @wrapper_gemfile
+    FileUtils.rm_f @wrapper_gemfile
+    FileUtils.rm_f "#{@wrapper_gemfile}.lock"
+  end
+
+  ##
+  # Returns the code string to be preloaded by the test runner process.
+  # It initializes the SpecReporter alongside a single-file JUnitReporter.
+  # If other custom reporters are already configured, they are preserved.
+  #
+  # @return [String] Ruby preloader code block
+  #
+  def junit_preload_code
+    <<~RUBY
+      if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+        if !defined?(Minitest::Reporters) || !Minitest::Reporters.respond_to?(:reporters) || Minitest::Reporters.reporters.nil? || Minitest::Reporters.reporters.none? { |r| r.class.name.include?("JUnitReporter") }
+          begin
+            require "fileutils"
+            FileUtils.mkdir_p("tmp/reports")
+            require "minitest/reporters"
+            unless defined? SpongeReporter
+              class SpongeReporter < Minitest::Reporters::JUnitReporter
+                private
+                # Override default reporter filename (TEST-minitest.xml) to write
+                # directly to sponge_log.xml as required by Kokoro/Sponge telemetry collection.
+                def filename_for suite
+                  File.join @reports_path, "sponge_log.xml"
+                end
+              end
+            end
+            existing = Minitest::Reporters.reporters || [Minitest::Reporters::SpecReporter.new]
+            existing = existing.reject { |r| r.class.name.include?("SpecReporter") }
+            Minitest::Reporters.use! [
+              Minitest::Reporters::SpecReporter.new,
+              SpongeReporter.new("tmp/reports", false, { single_file: true })
+            ] + existing
+          rescue LoadError => e
+            warn "Failed to load minitest-reporters: \#{e.message}"
+          end
+        end
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
Add GapicJunitHelper to format minitest execution output into JUnit XML reports. This enables centralized test result indexing, flake tracing, and build health metrics reporting inside TestGrid dashboards.