### PR TITLE
chore(ci): pin action versions to satisfy zizmor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,17 +45,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout repo
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: false
     - name: Install Ruby ${{ matrix.ruby }}
       uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
       with:
         ruby-version: "${{ matrix.ruby }}"
-    - name: Install NodeJS 20.x
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+    - name: Install NodeJS 24.x
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: "20.x"
+        node-version: "24.x"
     - name: Install tools and deps
       shell: bash
       run: "gem install --no-document toys && bundle install"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,8 @@
 name: CI
+
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:
@@ -41,13 +45,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      with:
+        persist-credentials: false
     - name: Install Ruby ${{ matrix.ruby }}
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
       with:
         ruby-version: "${{ matrix.ruby }}"
     - name: Install NodeJS 20.x
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: "20.x"
     - name: Install tools and deps
@@ -55,4 +61,6 @@ jobs:
       run: "gem install --no-document toys && bundle install"
     - name: Test
       shell: bash
-      run: toys ci ${{ matrix.jobs }} --include-owlbot-build --github-event-name=${{ github.event_name }} --github-event-payload=${GITHUB_EVENT_PATH} < /dev/null
+      env:
+        GITHUB_EVENT_NAME: ${{ github.event_name }}
+      run: toys ci ${{ matrix.jobs }} --include-owlbot-build --github-event-name="$GITHUB_EVENT_NAME" --github-event-payload="${GITHUB_EVENT_PATH}" < /dev/null

--- a/.kokoro/gas/trigger-generic.cfg
+++ b/.kokoro/gas/trigger-generic.cfg
@@ -31,7 +31,7 @@ env_vars: {
 # List of minor Ruby versions for generic builds, colon-delimited.
 env_vars: {
   key: "GAS_RUBY_VERSIONS"
-  value: "3.1:3.2:3.3:3.4"
+  value: "3.2:3.3:3.4:4.0"
 }
 
 # This must be set when invoking the job.


### PR DESCRIPTION
chore: Update trigger-generic.cfg to drop Ruby 3.1 and support 4.0
chore: Upgrade Node to v24 and pin actions

Used go/github-zizmor-help?polyglot=github-com#local-scans-run-zizmor-on-your-cloudtop