### PR TITLE
fix(toys/gapic): write JUnit sponge_log.xml to gem root

### DIFF
--- a/.toys/.toys.rb
+++ b/.toys/.toys.rb
@@ -18,6 +18,12 @@ expand :clean, paths: :gitignore
 
 expand :rubocop, bundler: true
 
+expand :minitest do |t|
+  t.libs = ["toys/gapic/lib"]
+  t.files = "toys/gapic/test/**/*_test.rb"
+  t.use_bundler
+end
+
 tool "release" do
   load ::File.join(::File.dirname(__dir__), "toys", "release")
 end

--- a/.toys/ci.rb
+++ b/.toys/ci.rb
@@ -78,6 +78,17 @@ def run_rubocop
 end
 
 def run_test
+  if File.directory? "toys/gapic/test"
+    puts "RUNNING: root tests", :bold, :cyan
+    result = exec_separate_tool ["test"], name: "Root tests"
+    if result.success?
+      puts "PASSED: root tests", :bold, :green
+    else
+      puts "FAILED: root tests", :bold, :red
+      @errors << "root"
+    end
+  end
+
   determine_dirs.each do |dir|
     name = "#{dir}: test"
     Dir.chdir dir do

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gem "google-style", "~> 1.32.0"
 gem "minitest-mock", "~> 5.27"
+gem "minitest-reporters", "~> 1.8.0"

--- a/toys/gapic/lib/gapic/minitest_junit_preloader.rb
+++ b/toys/gapic/lib/gapic/minitest_junit_preloader.rb
@@ -51,8 +51,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
             end
 
             unless has_junit
-              FileUtils.mkdir_p "tmp/reports"
-              reporters << SpongeReporter.new("tmp/reports", false, { single_file: true })
+              reporters << SpongeReporter.new(".", false, { single_file: true })
             end
 
             original_use! reporters

--- a/toys/gapic/test/minitest_junit_preloader_test.rb
+++ b/toys/gapic/test/minitest_junit_preloader_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "minitest/autorun"
+require "tmpdir"
+require "fileutils"
+require "English"
+
+class MinitestJunitPreloaderTest < Minitest::Test
+  def test_preloader_generates_xml_in_current_directory
+    Dir.mktmpdir do |dir|
+      write_dummy_test dir
+      output = run_subprocess dir
+
+      # Assert subprocess succeeded
+      assert $CHILD_STATUS.success?, "Dummy test execution in subprocess failed. Output:\n#{output}"
+
+      # Assert sponge_log.xml was generated directly inside `dir` (current directory)
+      xml_file = File.join dir, "sponge_log.xml"
+      assert File.exist?(xml_file), "Expected sponge_log.xml to be generated at the current directory"
+
+      # Assert no tmp/reports directory was created
+      refute File.exist?(File.join(dir, "tmp")), "Expected no tmp/ directory to be created"
+
+      # Verify XML content
+      xml_content = File.read xml_file
+      assert_includes xml_content, "<testsuite name=\"DummyTest\""
+      assert_includes xml_content, "<testcase name=\"test_success\""
+    end
+  end
+
+  private
+
+  def write_dummy_test dir
+    test_file = File.join dir, "dummy_test.rb"
+    File.write test_file, <<~RUBY
+      require "gapic/minitest_junit_preloader"
+      require "minitest/autorun"
+
+      class DummyTest < Minitest::Test
+        def test_success
+          assert true
+        end
+      end
+    RUBY
+  end
+
+  def run_subprocess dir
+    lib_dir = File.expand_path "../lib", __dir__
+    test_file = File.join dir, "dummy_test.rb"
+    cmd = [
+      "bundle", "exec", "ruby",
+      "-I", lib_dir,
+      test_file
+    ]
+    env = {
+      "CI" => "true",
+      "KOKORO_JOB_NAME" => "test"
+    }
+
+    IO.popen env, cmd, chdir: dir, &:read
+  end
+end


### PR DESCRIPTION
* Writing JUnit XML test reports to `tmp/reports/sponge_log.xml` caused Sponge to ignore the test cases (showing "no info") and create redundant targets containing the `/tmp/reports` path.
* Resolved by changing the preloader to output `sponge_log.xml` directly to each gem's root directory, matching the Go team's pattern.
* Added automated subprocess integration tests to protect against future output regressions.

refs: googleapis/google-cloud-ruby#34740