### PR TITLE
chore(toys/gapic): relocate preloader integration tests to root directory

### DIFF
--- a/.toys/.toys.rb
+++ b/.toys/.toys.rb
@@ -20,7 +20,7 @@ expand :rubocop, bundler: true
 
 expand :minitest do |t|
   t.libs = ["toys/gapic/lib"]
-  t.files = "toys/gapic/test/**/*_test.rb"
+  t.files = "test/**/*_test.rb"
   t.use_bundler
 end
 

--- a/.toys/ci.rb
+++ b/.toys/ci.rb
@@ -78,7 +78,7 @@ def run_rubocop
 end
 
 def run_test
-  if File.directory? "toys/gapic/test"
+  if File.directory? "test"
     puts "RUNNING: root tests", :bold, :cyan
     result = exec_separate_tool ["test"], name: "Root tests"
     if result.success?

--- a/test/minitest_junit_preloader_test.rb
+++ b/test/minitest_junit_preloader_test.rb
@@ -59,7 +59,7 @@ class MinitestJunitPreloaderTest < Minitest::Test
   end
 
   def run_subprocess dir
-    lib_dir = File.expand_path "../lib", __dir__
+    lib_dir = File.expand_path "../toys/gapic/lib", __dir__
     test_file = File.join dir, "dummy_test.rb"
     cmd = [
       "bundle", "exec", "ruby",


### PR DESCRIPTION
Because downstream configurations only load the toys/gapic subpath,
the repository root test/ directory is completely isolated from downstream
client gems. It will only be visible and executed during ruby-common-tools's
own internal CI checks.