### PR TITLE
fix(toys/gapic): format XML test duration as standard decimal

### DIFF
--- a/test/minitest_junit_preloader_test.rb
+++ b/test/minitest_junit_preloader_test.rb
@@ -39,6 +39,10 @@ class MinitestJunitPreloaderTest < Minitest::Test
       xml_content = File.read xml_file
       assert_includes xml_content, "<testsuite name=\"DummyTest\""
       assert_includes xml_content, "<testcase name=\"test_success\""
+
+      # Verify time duration format (must be decimal with 6 decimal places, no scientific notation)
+      assert_match(/time="\d+\.\d{6}"/, xml_content, "Expected duration formatted as 6-digit decimal")
+      refute_match(/time="[^"]*e-[^"]*"/, xml_content, "Expected duration not to use scientific notation")
     end
   end
 

--- a/toys/gapic/lib/gapic/minitest_junit_preloader.rb
+++ b/toys/gapic/lib/gapic/minitest_junit_preloader.rb
@@ -22,11 +22,76 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
     unless defined? SpongeReporter
       # Custom subclass of JUnitReporter that always outputs to a single sponge_log.xml
       # file inside the reports directory, to comply with Kokoro telemetry indexing.
+      #
+      # @note This class overrides private methods of Minitest::Reporters::JUnitReporter
+      #   and is coupled to its internal structure. If upgrading the minitest-reporters
+      #   dependency beyond 1.8.x, ensure these overrides are reviewed for compatibility.
       class SpongeReporter < Minitest::Reporters::JUnitReporter
         private
 
         def filename_for _suite
           File.join @reports_path, "sponge_log.xml"
+        end
+
+        # Overrides the parent method to orchestrate test suite XML generation.
+        #
+        # @param xml [Builder::XmlMarkup] The XML builder instance.
+        # @param suite [String] The name of the test suite class.
+        # @param tests [Array<Minitest::Result>] List of test cases in the suite.
+        def parse_xml_for xml, suite, tests
+          suite_result = analyze_suite tests
+          file_path = get_relative_path tests.first
+          attributes = build_suite_attributes suite, file_path, suite_result
+
+          xml.testsuite attributes do
+            tests.each do |test|
+              parse_xml_testcase xml, test, suite, file_path
+            end
+          end
+        end
+
+        # Constructs the attributes hash for the `<testsuite>` XML element.
+        # Overrides the default behavior of Minitest::Reporters::JUnitReporter,
+        # which falls back to scientific notation for very small duration values
+        # (e.g. 4.63e-05). Sponge's strict XSD schema validation for XML logs
+        # rejects scientific exponents in decimal attributes.
+        #
+        # @param suite [String] The name of the test suite.
+        # @param file_path [String] Relative path to the test file.
+        # @param suite_result [Hash] Analyzed results from the test suite.
+        # @return [Hash] Key-value attributes for the XML element.
+        def build_suite_attributes suite, file_path, suite_result
+          attributes = {
+            name: suite, filepath: file_path, skipped: suite_result[:skip_count],
+            failures: suite_result[:fail_count], errors: suite_result[:error_count],
+            tests: suite_result[:test_count], assertions: suite_result[:assertion_count],
+            time: format("%.6f", suite_result[:time])
+          }
+          attributes[:timestamp] = suite_result[:timestamp] if @timestamp_report
+          attributes
+        end
+
+        # Generates the XML node for a single `<testcase>` element.
+        # Overrides the default behavior of Minitest::Reporters::JUnitReporter,
+        # which falls back to scientific notation for very small duration values
+        # (e.g. 4.63e-05). Sponge's strict XSD schema validation for XML logs
+        # rejects scientific exponents in decimal attributes.
+        #
+        # @param xml [Builder::XmlMarkup] The XML builder instance.
+        # @param test [Minitest::Result] The specific test execution result.
+        # @param suite [String] The name of the test suite.
+        # @param file_path [String] Relative path to the test file.
+        def parse_xml_testcase xml, test, suite, file_path
+          lineno = get_source_location(test).last
+          xml.testcase(
+            name: test.name, lineno: lineno, classname: suite,
+            assertions: test.assertions, time: format("%.6f", test.time), file: file_path
+          ) do
+            xml << xml_message_for(test) unless test.passed?
+            if test.respond_to?("metadata") && test.metadata[:failure_screenshot_path]
+              xml << xml_attachment_for(test)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Override parse_xml_for in SpongeReporter to explicitly format time duration attributes.

Problem: Sponge test target logs are appearing empty ("no info"). Intermediate Cause: Sponge/ResultStore fails to parse the uploaded JUnit XML due to XSD schema validation errors: "not a valid value for 'decimal'". Root Cause: For very small values, minitest-reporters formats durations using scientific notation (e.g. 4.63e-05). The XSD decimal schema rejects scientific exponents. Explicitly formatting duration attributes using sprintf("%.6f", duration) ensures valid decimal representation.

Example failing Test Fusion log: https://fusion2.corp.google.com/invocations/e45c625c-ebe2-4017-bb4e-9ade70a68195/targets/github%2Fgoogle-cloud-ruby%2Fgoogle-cloud-logging;config=default/log

refs: googleapis/google-cloud-ruby#34740