### PR TITLE
chore: add temporary env debug diagnostics to trigger.sh

### DIFF
--- a/.kokoro/gas/trigger.sh
+++ b/.kokoro/gas/trigger.sh
@@ -7,5 +7,18 @@ set -eo pipefail
 export GEM_HOME=$HOME/.gem
 export PATH=$GEM_HOME/bin:$PATH
 
+echo "=== ENVIRONMENT DEBUG ==="
+echo "PATH: $PATH"
+echo "User ID: $(id)"
+echo "Kernel: $(uname -a)"
+echo "Glibc version: $(ldd --version | head -n 1)"
+echo "Docker path: $(which docker || echo 'Not found on PATH')"
+ls -l /usr/bin/docker || true
+ldd /usr/bin/docker || true
+ls -la /var/run/docker.sock || true
+docker version || true
+podman version || true
+echo "========================="
+
 cd gas
 toys gas kokoro-trigger -v


### PR DESCRIPTION
This temporary change adds diagnostic logging to `.kokoro/gas/trigger.sh` to troubleshoot a blocked release of the Ruby Protobuf library (v36.0-rc2).

* The Problem: The `trigger-protobuf` Kokoro job fails during cross-compiling with `Neither Docker nor Podman is available` (raised by `rake-compiler-dock`).
* Context: The staging image `ruby-release:latest` was upgraded to Ubuntu Noble (24.04). Local verification shows the Noble image builds correctly and contains a working `docker` client CLI.
* Diagnostics: This telemetry prints `PATH`, checks the location/permissions of the docker binary, runs `ldd`, and executes `docker version` directly in Kokoro. This will help isolate whether the image in the registry is stale/lacking Docker, or if there is a runtime compatibility issue (e.g., kernel or seccomp blocking system calls in Ubuntu Noble) crashing the client.