### PR TITLE
feat(owlbot): update Ruby Docker version to 4.0.6

### DIFF
--- a/owlbot-postprocessor/Dockerfile
+++ b/owlbot-postprocessor/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ruby:4.0.3-bookworm
+FROM ruby:4.0.6-bookworm
 RUN apt-get update \
     && apt-get -y upgrade \
     && apt-get -y autoremove \


### PR DESCRIPTION
Ruby 4.0.6 bundles net-imap 0.6.4.1, which resolves CVE-2026-42246 (present in older default gem versions).

Verified via:
```
❯ docker run --rm ruby:4.0.6-bookworm gem list net-imap

net-imap (0.6.4.1)
```