### PR TITLE
fix: export DOCKER_API_VERSION inside trigger.sh to bypass Kokoro env filter

### DIFF
--- a/.kokoro/gas/trigger-protobuf.cfg
+++ b/.kokoro/gas/trigger-protobuf.cfg
@@ -60,9 +60,5 @@ action {
   }
 }
 
-# Force Docker client to use legacy API version 1.39 to match Kokoro host daemon.
-env_vars: {
-  key: "DOCKER_API_VERSION"
-  value: "1.39"
-}
+
 

--- a/.kokoro/gas/trigger.sh
+++ b/.kokoro/gas/trigger.sh
@@ -6,6 +6,10 @@ set -eo pipefail
 # is in a read-only location.
 export GEM_HOME=$HOME/.gem
 export PATH=$GEM_HOME/bin:$PATH
+
+# Force Docker client to use legacy API version 1.39 to match Kokoro host daemon.
+export DOCKER_API_VERSION=1.39
+
 echo "=== ENVIRONMENT DEBUG ==="
 echo "PATH: $PATH"
 echo "User ID: $(id)"


### PR DESCRIPTION
refs: #442
refs: #446