### PR TITLE
chore(tombstone-library): generate Rakefile for release builds

### DIFF
--- a/toys/tombstone-library/.data/rakefile-template.erb
+++ b/toys/tombstone-library/.data/rakefile-template.erb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Copyright <%= Time.now.year %> Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "bundler/setup"
+require "bundler/gem_tasks"

--- a/toys/tombstone-library/.toys.rb
+++ b/toys/tombstone-library/.toys.rb
@@ -97,6 +97,7 @@ def generate_files
     generate_one "LICENSE.md", "license-template.erb"
     generate_one "#{gem_name}.gemspec", "gemspec-template.erb"
     generate_one ".yardopts", "yardopts-template.erb"
+    generate_one "Rakefile", "rakefile-template.erb"
     mkdir_p "lib/#{namespace_dir}"
     generate_one "lib/#{namespace_dir}/version.rb", "version-template.erb"
   end


### PR DESCRIPTION
When tombstoning a library using `toys tombstone-library`, all existing files in the gem directory are purged and replaced with a minimal tombstone skeleton (`README.md`, `LICENSE.md`, `.gemspec`, `.yardopts`, `version.rb`). However, the tool previously omitted a `Rakefile`, leading to errors when releasing the tombstoned version of the package.

### Context & Failure Mode

During the recent tombstoning of the `stackdriver` gem ([googleapis/google-cloud-ruby#34614](https://github.com/googleapis/google-cloud-ruby/pull/34614)), automated release packaging via `release-please` (triggered on tag `stackdriver/v1.0.0`) failed in the release CI/CD workflow with:

```
rake aborted!
Don't know how to build task 'build' (See the list of available tasks with `rake --tasks`)
```

Because release packaging automation relies on executing `bundle exec rake build` to compile the `.gem` artifact prior to RubyGems publication, the absence of a `Rakefile` invoking `bundler/gem_tasks` aborted the release pipeline. We had to manually push a follow-up patch PR ([googleapis/google-cloud-ruby#34652](https://github.com/googleapis/google-cloud-ruby/pull/34652)) to restore a minimal `Rakefile`, which caused release tag collisions and required manual changelog fixes.

### Changes

- Adds `toys/tombstone-library/.data/rakefile-template.erb` containing the standard license header, `require "bundler/setup"`, and `require "bundler/gem_tasks"`.
- Updates `generate_files` in `toys/tombstone-library/.toys.rb` to generate `Rakefile` automatically when tombstoning any library.

### Downstream Reference

Tested and validated downstream against the Apigee Registry tombstone draft PR: [googleapis/google-cloud-ruby#36233](https://github.com/googleapis/google-cloud-ruby/pull/36233).