### PR TITLE
chore(tombstone-library): fix version.rb require and files path in gemspec template

### DIFF
--- a/toys/tombstone-library/.data/gemspec-template.erb
+++ b/toys/tombstone-library/.data/gemspec-template.erb
@@ -1,4 +1,4 @@
-require File.expand_path("<%= namespace_dir %>/version", __dir__)
+require File.expand_path("lib/<%= namespace_dir %>/version", __dir__)
 
 Gem::Specification.new do |gem|
   gem.name = "<%= gem_name %>"
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.homepage = "https://github.com/googleapis/google-cloud-ruby"
   gem.license = "Apache-2.0"
   gem.platform = Gem::Platform::RUBY
-  gem.files = ["README.md", "LICENSE.md", ".yardopts", "<%= namespace_dir %>/version.rb"]
+  gem.files = ["README.md", "LICENSE.md", ".yardopts", "lib/<%= namespace_dir %>/version.rb"]
   gem.require_paths = ["lib"]
   gem.required_ruby_version = ">= 3.0"
 end


### PR DESCRIPTION
Fixes the path to `version.rb` in `gemspec-template.erb` when tombstoning a gem.

### Technical Context

In `toys/tombstone-library/.toys.rb`, `generate_files` writes the tombstone version constant to:
```ruby
mkdir_p "lib/#{namespace_dir}"
generate_one "lib/#{namespace_dir}/version.rb", "version-template.erb"
```

However, `gemspec-template.erb` previously omitted the `lib/` directory prefix:
- `require File.expand_path("<%= namespace_dir %>/version", __dir__)` -> `require File.expand_path("lib/<%= namespace_dir %>/version", __dir__)`
- `gem.files = [..., "<%= namespace_dir %>/version.rb"]` -> `gem.files = [..., "lib/<%= namespace_dir %>/version.rb"]`

### Failure Modes Resolved

1. **Gemspec Loading / Build Failures:** Any evaluation of the generated gemspec (via `rake build`, `bundle install`, or `Gem::Specification.load`) previously attempted to require `<gem_root>/<namespace>/version.rb`, raising `LoadError: cannot load such file`.
2. **Missing Version File in Package:** Because `gem.files` did not reference `lib/<namespace_dir>/version.rb`, `gem build` failed to include `version.rb` in the packaged `.gem` archive.

### Repro & Verification

```bash
# 1. Create dummy multi-namespace skeleton
mkdir -p my-sample-gem/lib/my/sample/gem
touch my-sample-gem/{README.md,LICENSE.md,.yardopts}
cat << 'EOF' > my-sample-gem/lib/my/sample/gem/version.rb
module My; module Sample; module Gem; VERSION = "1.0.0"; end; end; end
EOF

# 2. Testing unpatched template (fails with LoadError):
# require File.expand_path("my/sample/gem/version", __dir__)
ruby -e "Gem::Specification.load('my-sample-gem/my-sample-gem.gemspec')"
# => LoadError: cannot load such file -- .../my-sample-gem/my/sample/gem/version

# 3. Testing patched template (passes & builds package cleanly):
# require File.expand_path("lib/my/sample/gem/version", __dir__)
ruby -e "spec = Gem::Specification.load('my-sample-gem/my-sample-gem.gemspec'); puts spec.name + ' ' + spec.version.to_s"
# => my-sample-gem 1.0.0
```