### PR TITLE
chore(tombstone-library): use https for Apache license URLs

### DIFF
--- a/toys/tombstone-library/.data/license-template.erb
+++ b/toys/tombstone-library/.data/license-template.erb
@@ -1,6 +1,6 @@
                                   Apache License
                             Version 2.0, January 2004
-                         http://www.apache.org/licenses/
+                         https://www.apache.org/licenses/
 
     TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/toys/tombstone-library/.data/version-template.erb
+++ b/toys/tombstone-library/.data/version-template.erb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/toys/tombstone-library/.toys.rb
+++ b/toys/tombstone-library/.toys.rb
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Updates Apache License 2.0 URLs in `toys/tombstone-library` templates from `http://` to `https://`.

### Changes

- Updates `toys/tombstone-library/.data/license-template.erb` header and appendix URL to `https://www.apache.org/licenses/` and `https://www.apache.org/licenses/LICENSE-2.0`.
- Updates `toys/tombstone-library/.data/version-template.erb` license header to `https://www.apache.org/licenses/LICENSE-2.0`.
- Updates `toys/tombstone-library/.toys.rb` file header to `https://www.apache.org/licenses/LICENSE-2.0`.